### PR TITLE
fix missing import and create output path

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import torch
 from model import build_model
@@ -84,6 +85,7 @@ for meta in tqdm(test_meta):
     converted_feat = model.generator(trg_spk_emb, vqwav2vec_feature)
     
     cvt_wav = vocoder.inference(converted_feat.transpose(-1,-2).squeeze())
+    os.makedirs('converted_wavs', exist_ok=True)
     converted_wav_path = os.path.join('converted_wavs',f'{src_spk}_{trg_spk}_{f_id}')
     sf.write(converted_wav_path, cvt_wav.data.numpy(), 24000, "PCM_16")   
 print(f'total time {time.time() - start}')


### PR DESCRIPTION
Needed to add os import:
```
Traceback (most recent call last):
  File "inference.py", line 88, in <module>
    converted_wav_path = os.path.join('converted_wavs',f'{src_spk}_{trg_spk}_{f_id}')
NameError: name 'os' is not defined

```
and needed to create output directory if it doesn't already exist:
```
Traceback (most recent call last):
  File "inference.py", line 90, in <module>
    sf.write(converted_wav_path, cvt_wav.data.numpy(), 24000, "PCM_16")   
  File "soundfile.py", line 315, in write
    subtype, endian, format, closefd) as f:
  File "soundfile.py", line 629, in __init__
    self._file = self._open(file, mode_int, closefd)
  File "soundfile.py", line 1184, in _open
    "Error opening {0!r}: ".format(self.name))
  File "soundfile.py", line 1357, in _error_check
    raise RuntimeError(prefix + _ffi.string(err_str).decode('utf-8', 'replace'))
RuntimeError: Error opening 'converted_wavs/vcc20_vcc20_E30001.wav': System error.
```